### PR TITLE
[fix]: 'application.properties' 내에 DB명 수정 및 MySQL driver명 정정 (#3)

### DIFF
--- a/bssBack/src/main/resources/application.properties
+++ b/bssBack/src/main/resources/application.properties
@@ -1,11 +1,11 @@
 
 spring.jpa.hibernate.ddl-auto = update
-spring.datasource.url = jdbc:mysql://${root:localhost}:3306/besisi
+spring.datasource.url = jdbc:mysql://${root:localhost}:3306/baesisi
 spring.datasource.username = root
 
-spring.datasource.password = #password
+spring.datasource.password = ENTER_YOUR_PASSWORD
 
-spring.datasource.driverClassName=com.mysql.cj.jdbc.Drivergit 
+spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
 server.port = 9090
 
 spring.servlet.multipart.maxFileSize=100MB


### PR DESCRIPTION
## 👀 이슈

resolve #3 

## 📌 개요

`application.properties` 내에 DB명 수정을 조직명에 맞게
변경하고, MySQL driver명 정정하였습니다.

## 👩‍💻 작업 사항

- `application.properties` 내에 DB명 수정
- `application.properties` 내에 MySQL driver명 정정

## ✅ 참고 사항

없습니다
