### PR TITLE
[fix]: DB명 변경에 따른 SQL DB 선택 명령문 수정 (#5)

### DIFF
--- a/SQL/UserSQL.sql
+++ b/SQL/UserSQL.sql
@@ -1,6 +1,6 @@
 create database baesisi;
 
-use besisi;
+use baesisi;
 
 CREATE TABLE `attempt` (
   `id` bigint NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
## 👀 이슈

resolve #5 

## 📌 개요

DB명이 변경됨에 따라 기존 **besisi**로 사용되던 DB명을
**baesisi**로 변경하였습니다.

## 👩‍💻 작업 사항

- **`UserSQL.sql`** 파일 내 DB 선택 SQL 명령문 수정
```sql
use besisi; -> use baesisi;
```

## ✅ 참고 사항

없습니다
